### PR TITLE
Add API response types to member endpoints and create member/team type file

### DIFF
--- a/src/APITypes.d.ts
+++ b/src/APITypes.d.ts
@@ -1,0 +1,11 @@
+import { Member } from './DataTypes';
+
+type ErrorResponse = {
+  error: string;
+  status: number;
+};
+
+type MemberResponse = {
+  status: number;
+  member: Member;
+};

--- a/src/APITypes.d.ts
+++ b/src/APITypes.d.ts
@@ -9,3 +9,8 @@ type MemberResponse = {
   status: number;
   member: Member;
 };
+
+type AllMembersResponse = {
+  status: number;
+  members: Member[];
+};

--- a/src/DataTypes.d.ts
+++ b/src/DataTypes.d.ts
@@ -1,0 +1,33 @@
+import { firestore } from 'firebase-admin';
+
+type Member = {
+  email: string;
+  first_name: string;
+  last_name: string;
+  role: string;
+  graduation: string;
+  major: string;
+  double_major?: string; //optional
+  minor?: string; //optional
+  website?: string; //optional
+  linkedin_link?: string; //optional
+  github_link?: string; //optional
+  hometown: string;
+  about: string;
+  subteam: string;
+  other_subteams?: string[]; // optional
+};
+
+type DBTeam = {
+  uuid: string;
+  name: string;
+  leaders: firestore.DocumentReference[];
+  members: firestore.DocumentReference[];
+};
+
+type Team = {
+  uuid: string;
+  name: string;
+  leaders: Member[];
+  members: Member[];
+};

--- a/src/DataTypes.d.ts
+++ b/src/DataTypes.d.ts
@@ -1,5 +1,7 @@
 import { firestore } from 'firebase-admin';
 
+type role = 'lead' | 'admin' | 'tpm' | 'pm' | 'developer' | 'designer';
+
 type Member = {
   email: string;
   first_name: string;

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,12 +17,12 @@ const db = database;
 const PORT = process.env.PORT || 9000;
 const isProd: boolean = JSON.parse(process.env.IS_PROD);
 const allowAllOrigins = false;
-const enforceSession = false;
+const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-  : [/http:\/\/localhost:3000/];
+    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+    : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(

--- a/src/api.ts
+++ b/src/api.ts
@@ -128,7 +128,7 @@ router.post('/setMember', async (req, res) => {
   res.status(handled.status).json(handled);
 });
 
-router.post('/deleteMember', async (req, res) => {
+router.delete('/deleteMember', async (req, res) => {
   let handled = await deleteMember(req, res);
   res.status(handled.status).json(handled);
 });
@@ -141,7 +141,7 @@ router.post('/updateMember', async (req, res) => {
 // Teams
 router.get('/allTeams', allTeams);
 router.post('/setTeam', setTeam);
-router.post('/deleteTeam', deleteTeam);
+router.delete('/deleteTeam', deleteTeam);
 
 app.use('/.netlify/functions/api', router);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -114,9 +114,14 @@ router.get('/allRoles', getAllRoles);
 
 // Members
 router.get('/allMembers', allMembers);
-router.get('/getMember/:email', getMember);
+
+router.get('/getMember/:email', async (req, res) => {
+  let handled = await getMember(req, res);
+  res.status(handled.status).json(handled);
+});
 router.post('/setMember', setMember);
 router.post('/deleteMember', deleteMember);
+
 router.post('/updateMember', async (req, res) => {
   let handled = await updateMember(req, res);
   res.status(handled.status).json(handled);

--- a/src/api.ts
+++ b/src/api.ts
@@ -114,7 +114,7 @@ router.get('/allRoles', getAllRoles);
 
 // Members
 router.get('/allMembers', allMembers);
-router.post('/getMember/:email', getMember);
+router.get('/getMember/:email', getMember);
 router.post('/setMember', setMember);
 router.post('/deleteMember', deleteMember);
 router.post('/updateMember', updateMember);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,14 +1,20 @@
-require("dotenv").config();
-import express from "express";
-import serverless from "serverless-http";
-import cors from "cors";
-import session, { MemoryStore } from "express-session";
-import { db as database, app as adminApp } from "./firebase";
-import bodyParser from "body-parser";
-import admin from "firebase-admin";
-import { allMembers, getMember, setMember, deleteMember, updateMember } from "./memberAPI";
-import { getAllRoles } from "./roleAPI";
-import { allTeams, setTeam, deleteTeam } from "./teamAPI";
+require('dotenv').config();
+import express from 'express';
+import serverless from 'serverless-http';
+import cors from 'cors';
+import session, { MemoryStore } from 'express-session';
+import { db as database, app as adminApp } from './firebase';
+import bodyParser from 'body-parser';
+import admin from 'firebase-admin';
+import {
+  allMembers,
+  getMember,
+  setMember,
+  deleteMember,
+  updateMember,
+} from './memberAPI';
+import { getAllRoles } from './roleAPI';
+import { allTeams, setTeam, deleteTeam } from './teamAPI';
 
 // Constants and configurations
 const app = express();
@@ -17,12 +23,12 @@ const db = database;
 const PORT = process.env.PORT || 9000;
 const isProd: boolean = JSON.parse(process.env.IS_PROD);
 const allowAllOrigins = false;
-const enforceSession = true;
+const enforceSession = false;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-    : [/http:\/\/localhost:3000/];
+  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+  : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(
@@ -57,15 +63,15 @@ export let checkLoggedIn = (req, res): boolean => {
     return true;
   } else {
     // Session expired
-    res.status(440).json({ error: "Not logged in!" });
+    res.status(440).json({ error: 'Not logged in!' });
     return false;
   }
 };
 
 // Login
-router.post("/login", async (req, res) => {
+router.post('/login', async (req, res) => {
   let members = await db
-    .collection("members")
+    .collection('members')
     .get()
     .then((vals) => {
       return vals.docs.map((doc) => {
@@ -95,7 +101,7 @@ router.post("/login", async (req, res) => {
 });
 
 // Logout
-router.post("/logout", (req, res) => {
+router.post('/logout', (req, res) => {
   req.session.isLoggedIn = false;
   req.session.destroy((err) => {
     err ? sessionErrCb(err) : null;
@@ -104,26 +110,26 @@ router.post("/logout", (req, res) => {
 });
 
 // Roles
-router.get("/allRoles", getAllRoles);
+router.get('/allRoles', getAllRoles);
 
 // Members
-router.get("/allMembers", allMembers);
-router.get('./getMember', getMember)
-router.post("/setMember", setMember);
-router.post("/deleteMember", deleteMember);
-router.post("/updateMember", updateMember);
+router.get('/allMembers', allMembers);
+router.post('/getMember/:email', getMember);
+router.post('/setMember', setMember);
+router.post('/deleteMember', deleteMember);
+router.post('/updateMember', updateMember);
 
 // Teams
-router.get("/allTeams", allTeams);
-router.post("/setTeam", setTeam);
-router.post("/deleteTeam", deleteTeam);
+router.get('/allTeams', allTeams);
+router.post('/setTeam', setTeam);
+router.post('/deleteTeam', deleteTeam);
 
-app.use("/.netlify/functions/api", router);
+app.use('/.netlify/functions/api', router);
 
 // Startup local server if not production (prod is serverless)
 if (!isProd) {
   app.listen(PORT, () => {
-    console.log("IDOL backend listening on port: " + PORT);
+    console.log('IDOL backend listening on port: ' + PORT);
   });
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,14 +1,14 @@
-require('dotenv').config();
-import express from 'express';
-import serverless from 'serverless-http';
-import cors from 'cors';
-import session, { MemoryStore } from 'express-session';
-import { db as database, app as adminApp } from './firebase';
-import bodyParser from 'body-parser';
+require("dotenv").config();
+import express from "express";
+import serverless from "serverless-http";
+import cors from "cors";
+import session, { MemoryStore } from "express-session";
+import { db as database, app as adminApp } from "./firebase";
+import bodyParser from "body-parser";
 import admin from "firebase-admin";
-import { allMembers, setMember, deleteMember } from './memberAPI';
-import { getAllRoles } from './roleAPI';
-import { allTeams, setTeam, deleteTeam } from './teamAPI';
+import { allMembers, setMember, deleteMember, updateMember } from "./memberAPI";
+import { getAllRoles } from "./roleAPI";
+import { allTeams, setTeam, deleteTeam } from "./teamAPI";
 
 // Constants and configurations
 const app = express();
@@ -17,28 +17,36 @@ const db = database;
 const PORT = process.env.PORT || 9000;
 const isProd: boolean = JSON.parse(process.env.IS_PROD);
 const allowAllOrigins = false;
-const enforceSession = true;
-const allowedOrigins = allowAllOrigins ? [/.*/] : (isProd
+const enforceSession = false;
+const allowedOrigins = allowAllOrigins
+  ? [/.*/]
+  : isProd
   ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-  : [/http:\/\/localhost:3000/]);
+  : [/http:\/\/localhost:3000/];
 
 // Middleware
-app.use(cors({
-  origin: allowedOrigins,
-  credentials: true,
-}));
+app.use(
+  cors({
+    origin: allowedOrigins,
+    credentials: true,
+  })
+);
 app.use(bodyParser.json());
-app.use(session({
-  secret: process.env.SESSION_SECRET,
-  resave: true,
-  saveUninitialized: true,
-  store: new MemoryStore(),
-  cookie: {
-    secure: isProd ? true : false,
-    maxAge: 3600000
-  }
-}));
-let sessionErrCb = (err) => { console.log(err); };
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET,
+    resave: true,
+    saveUninitialized: true,
+    store: new MemoryStore(),
+    cookie: {
+      secure: isProd ? true : false,
+      maxAge: 3600000,
+    },
+  })
+);
+let sessionErrCb = (err) => {
+  console.log(err);
+};
 
 // Check valid session
 export let checkLoggedIn = (req, res): boolean => {
@@ -52,35 +60,42 @@ export let checkLoggedIn = (req, res): boolean => {
     res.status(440).json({ error: "Not logged in!" });
     return false;
   }
-}
+};
 
 // Login
-router.post('/login', async (req, res) => {
-  let members = await db.collection('members').get().then((vals) => {
-    return vals.docs.map(doc => {
-      return doc.data();
+router.post("/login", async (req, res) => {
+  let members = await db
+    .collection("members")
+    .get()
+    .then((vals) => {
+      return vals.docs.map((doc) => {
+        return doc.data();
+      });
     });
-  });
   let auth_token = req.body.auth_token;
-  admin.auth(adminApp).verifyIdToken(auth_token).then((decoded) => {
-    let foundMember = members.find((val) => val.email === decoded.email);
-    if (!foundMember) {
+  admin
+    .auth(adminApp)
+    .verifyIdToken(auth_token)
+    .then((decoded) => {
+      let foundMember = members.find((val) => val.email === decoded.email);
+      if (!foundMember) {
+        res.json({ isLoggedIn: false });
+        return;
+      }
+      req.session.isLoggedIn = true;
+      req.session.email = foundMember.email;
+      req.session.save((err) => {
+        err ? sessionErrCb(err) : null;
+        res.json({ isLoggedIn: true });
+      });
+    })
+    .catch((reason) => {
       res.json({ isLoggedIn: false });
-      return;
-    }
-    req.session.isLoggedIn = true;
-    req.session.email = foundMember.email;
-    req.session.save((err) => {
-      err ? sessionErrCb(err) : null;
-      res.json({ isLoggedIn: true });
     });
-  }).catch((reason) => {
-    res.json({ isLoggedIn: false });
-  });
 });
 
 // Logout
-router.post('/logout', (req, res) => {
+router.post("/logout", (req, res) => {
   req.session.isLoggedIn = false;
   req.session.destroy((err) => {
     err ? sessionErrCb(err) : null;
@@ -89,20 +104,20 @@ router.post('/logout', (req, res) => {
 });
 
 // Roles
-router.get('/allRoles', getAllRoles);
+router.get("/allRoles", getAllRoles);
 
 // Members
-router.get('/allMembers', allMembers);
-router.post('/setMember', setMember);
-router.post('/deleteMember', deleteMember);
+router.get("/allMembers", allMembers);
+router.post("/setMember", setMember);
+router.post("/deleteMember", deleteMember);
+router.post("/updateMember", updateMember);
 
 // Teams
-router.get('/allTeams', allTeams);
-router.post('/setTeam', setTeam);
-router.post('/deleteTeam', deleteTeam);
+router.get("/allTeams", allTeams);
+router.post("/setTeam", setTeam);
+router.post("/deleteTeam", deleteTeam);
 
-
-app.use('/.netlify/functions/api', router);
+app.use("/.netlify/functions/api", router);
 
 // Startup local server if not production (prod is serverless)
 if (!isProd) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -119,7 +119,12 @@ router.get('/getMember/:email', async (req, res) => {
   let handled = await getMember(req, res);
   res.status(handled.status).json(handled);
 });
-router.post('/setMember', setMember);
+
+router.post('/setMember', async (req, res) => {
+  let handled = await setMember(req, res);
+  res.status(handled.status).json(handled);
+});
+
 router.post('/deleteMember', deleteMember);
 
 router.post('/updateMember', async (req, res) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@ import session, { MemoryStore } from "express-session";
 import { db as database, app as adminApp } from "./firebase";
 import bodyParser from "body-parser";
 import admin from "firebase-admin";
-import { allMembers, setMember, deleteMember, updateMember } from "./memberAPI";
+import { allMembers, getMember, setMember, deleteMember, updateMember } from "./memberAPI";
 import { getAllRoles } from "./roleAPI";
 import { allTeams, setTeam, deleteTeam } from "./teamAPI";
 
@@ -108,6 +108,7 @@ router.get("/allRoles", getAllRoles);
 
 // Members
 router.get("/allMembers", allMembers);
+router.get('./getMember', getMember)
 router.post("/setMember", setMember);
 router.post("/deleteMember", deleteMember);
 router.post("/updateMember", updateMember);

--- a/src/api.ts
+++ b/src/api.ts
@@ -117,7 +117,10 @@ router.get('/allMembers', allMembers);
 router.get('/getMember/:email', getMember);
 router.post('/setMember', setMember);
 router.post('/deleteMember', deleteMember);
-router.post('/updateMember', updateMember);
+router.post('/updateMember', async (req, res) => {
+  let handled = await updateMember(req, res);
+  res.status(handled.status).json(handled);
+});
 
 // Teams
 router.get('/allTeams', allTeams);

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,7 +23,7 @@ const db = database;
 const PORT = process.env.PORT || 9000;
 const isProd: boolean = JSON.parse(process.env.IS_PROD);
 const allowAllOrigins = false;
-const enforceSession = false;
+const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,7 +23,7 @@ const db = database;
 const PORT = process.env.PORT || 9000;
 const isProd: boolean = JSON.parse(process.env.IS_PROD);
 const allowAllOrigins = false;
-const enforceSession = true;
+const enforceSession = false;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
@@ -113,7 +113,10 @@ router.post('/logout', (req, res) => {
 router.get('/allRoles', getAllRoles);
 
 // Members
-router.get('/allMembers', allMembers);
+router.get('/allMembers', async (req, res) => {
+  let handled = await allMembers(req, res);
+  res.status(handled.status).json(handled);
+});
 
 router.get('/getMember/:email', async (req, res) => {
   let handled = await getMember(req, res);
@@ -125,7 +128,10 @@ router.post('/setMember', async (req, res) => {
   res.status(handled.status).json(handled);
 });
 
-router.post('/deleteMember', deleteMember);
+router.post('/deleteMember', async (req, res) => {
+  let handled = await deleteMember(req, res);
+  res.status(handled.status).json(handled);
+});
 
 router.post('/updateMember', async (req, res) => {
   let handled = await updateMember(req, res);

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -2,24 +2,8 @@ import { checkLoggedIn } from './api';
 import { db } from './firebase';
 import { PermissionsManager } from './permissions';
 import { Request, Response } from 'express';
-
-export type Member = {
-  email: string;
-  first_name: string;
-  last_name: string;
-  role: string;
-  graduation: string;
-  major: string;
-  double_major?: string; //optional
-  minor?: string; //optional
-  website?: string; //optional
-  linkedin_link?: string; //optional
-  github_link?: string; //optional
-  hometown: string;
-  about: string;
-  subteam: string;
-  other_subteams?: string[]; // optional
-};
+import { ErrorResponse, MemberResponse } from './APITypes';
+import { Member } from './DataTypes';
 
 export let allMembers = async (req, res) => {
   if (checkLoggedIn(req, res)) {
@@ -43,12 +27,12 @@ export let setMember = async (req, res) => {
     ).data();
     if (!member) {
       res
-        .status(200)
+        .status(401)
         .json({ error: 'No member with email: ' + req.session.email });
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit) {
-        res.status(200).json({
+        res.status(403).json({
           error:
             'User with email: ' +
             req.session.email +
@@ -57,7 +41,7 @@ export let setMember = async (req, res) => {
       } else {
         if (!req.body.email || req.body.email === '') {
           res
-            .status(200)
+            .status(400)
             .json({ error: "Couldn't edit user with undefined email!" });
           return;
         }
@@ -68,7 +52,7 @@ export let setMember = async (req, res) => {
           })
           .catch((reason) => {
             res
-              .status(200)
+              .status(500)
               .json({ error: "Couldn't edit user for reason: " + reason });
           });
       }
@@ -76,57 +60,124 @@ export let setMember = async (req, res) => {
   }
 };
 
-export let updateMember = async (req: Request, res: Response) => {
+export let updateMember = async (
+  req: Request,
+  res: Response
+): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
     let member = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
     if (!member) {
-      res
-        .status(200)
-        .json({ error: 'No member with email: ' + req.session.email });
+      return {
+        error: 'No member with email: ' + req.session.email,
+        status: 401,
+      };
     } else {
-      let canEdit = PermissionsManager.canEditMembers(member.role);
+      let canEdit: boolean = PermissionsManager.canEditMembers(member.role);
       if (!canEdit && member.email !== req.body.email) {
-        // members are able to edit their own information
-        res.status(200).json({
+        return {
           error:
             'User with email: ' +
             req.session.email +
             ' does not have permission to edit members!',
-        });
+          status: 403,
+        };
       } else {
         if (!req.body.email || req.body.email === '') {
-          res
-            .status(200)
-            .json({ error: "Couldn't edit user with undefined email!" });
-          return;
+          return {
+            error: "Couldn't edit user with undefined email!",
+            status: 400,
+          };
         }
         if (
           (req.body.role || req.body.first_name || req.body.last_name) &&
           !canEdit
         ) {
-          res.status(200).json({
+          return {
+            status: 403,
             error:
               'User with email: ' +
               req.session.email +
               ' does not have permission to edit member name or roles!',
-          });
+          };
         }
-        db.doc('members/' + req.body.email)
+        let response: ErrorResponse | MemberResponse = await db
+          .doc('members/' + req.body.email)
           .update(req.body)
           .then(() => {
-            res.status(200).json({ status: 'Success', member: req.body });
+            return {
+              member: req.body as Member,
+              status: 200,
+            };
           })
           .catch((reason) => {
-            res
-              .status(200)
-              .json({ error: "Couldn't edit user for reason: " + reason });
+            return {
+              error: "Couldn't edit user for reason: " + reason,
+              status: 500,
+            };
           });
+
+        return response;
       }
     }
   }
 };
+
+// export let updateMember = async (
+//   req: Request,
+//   res: Response
+// ): Promise<UpdateMemberResponse | ErrorResponse> => {
+//   if (checkLoggedIn(req, res)) {
+//     let member = await (
+//       await db.doc('members/' + req.session.email).get()
+//     ).data();
+//     if (!member) {
+//       res
+//         .status(401)
+//         .json({ error: 'No member with email: ' + req.session.email });
+//     } else {
+//       let canEdit = PermissionsManager.canEditMembers(member.role);
+//       if (!canEdit && member.email !== req.body.email) {
+//         // members are able to edit their own information
+//         res.status(403).json({
+//           error:
+//             'User with email: ' +
+//             req.session.email +
+//             ' does not have permission to edit members!',
+//         });
+//       } else {
+//         if (!req.body.email || req.body.email === '') {
+//           res
+//             .status(400)
+//             .json({ error: "Couldn't edit user with undefined email!" });
+//           return;
+//         }
+//         if (
+//           (req.body.role || req.body.first_name || req.body.last_name) &&
+//           !canEdit
+//         ) {
+//           res.status(403).json({
+//             error:
+//               'User with email: ' +
+//               req.session.email +
+//               ' does not have permission to edit member name or roles!',
+//           });
+//         }
+//         db.doc('members/' + req.body.email)
+//           .update(req.body)
+//           .then(() => {
+//             res.status(200).json({ status: 'Success', member: req.body });
+//           })
+//           .catch((reason) => {
+//             res
+//               .status(500)
+//               .json({ error: "Couldn't edit user for reason: " + reason });
+//           });
+//       }
+//     }
+//   }
+// };
 
 export let getMember = async (req: Request, res: Response) => {
   console.log(req.session.email);
@@ -136,15 +187,14 @@ export let getMember = async (req: Request, res: Response) => {
     ).data();
     console.log(member);
     if (!member) {
-      res // TODO: change the response status code
-        .status(200)
+      res
+        .status(401)
         .json({ error: 'No member with email:' + req.session.email });
     } else {
       let canEdit: boolean = PermissionsManager.canEditMembers(member.role);
       let memberEmail: string = req.params.email;
       if (!canEdit && memberEmail !== req.session.email) {
-        // TODO: change the response status code
-        res.status(200).json({
+        res.status(403).json({
           error:
             'User with email: ' +
             req.session.email +
@@ -165,12 +215,12 @@ export let deleteMember = async (req, res) => {
     ).data();
     if (!member) {
       res
-        .status(200)
+        .status(401)
         .json({ error: 'No member with email: ' + req.session.email });
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit) {
-        res.status(200).json({
+        res.status(403).json({
           error:
             'User with email: ' +
             req.session.email +

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -20,40 +20,46 @@ export let allMembers = async (req, res) => {
   }
 };
 
-export let setMember = async (req, res) => {
+export let setMember = async (
+  req,
+  res
+): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
     let member = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
     if (!member) {
-      res
-        .status(401)
-        .json({ error: 'No member with email: ' + req.session.email });
+      return {
+        error: 'No member with email: ' + req.session.email,
+        status: 401,
+      };
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit) {
-        res.status(403).json({
+        return {
           error:
             'User with email: ' +
             req.session.email +
             ' does not have permission to edit members!',
-        });
+          status: 403,
+        };
       } else {
         if (!req.body.email || req.body.email === '') {
-          res
-            .status(400)
-            .json({ error: "Couldn't edit user with undefined email!" });
-          return;
+          return {
+            error: "Couldn't edit user with undefined email!",
+            status: 400,
+          };
         }
         db.doc('members/' + req.body.email)
           .set(req.body)
           .then(() => {
-            res.status(200).json({ status: 'Success', member: req.body });
+            return { status: 200, member: req.body };
           })
           .catch((reason) => {
-            res
-              .status(500)
-              .json({ error: "Couldn't edit user for reason: " + reason });
+            return {
+              error: "Couldn't edit user for reason: " + reason,
+              status: 500,
+            };
           });
       }
     }

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -132,7 +132,6 @@ export let getMember = async (
   req: Request,
   res: Response
 ): Promise<MemberResponse | ErrorResponse> => {
-  console.log(req.session.email);
   if (checkLoggedIn(req, res)) {
     let member = await (
       await db.doc('members/' + req.session.email).get()

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -133,16 +133,15 @@ export let getMember = async (
   res: Response
 ): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
-    let member = await (
-      await db.doc('members/' + req.session.email).get()
-    ).data();
-    if (!member) {
+    let user = await (await db.doc('members/' + req.session.email).get()
+      .data();
+    if (!user) {
       return {
         error: 'No member with email: ' + req.session.email,
         status: 401,
       };
     } else {
-      let canEdit: boolean = PermissionsManager.canEditMembers(member.role);
+      let canEdit: boolean = PermissionsManager.canEditMembers(user.role);
       let memberEmail: string = req.params.email;
       if (!canEdit && memberEmail !== req.session.email) {
         return {
@@ -153,10 +152,16 @@ export let getMember = async (
           status: 403,
         };
       }
-
+      let member = await (await db.doc('members/' + memberEmail).get()).data();
+      if (!member) {
+        return {
+          status: 404,
+          error: 'Member with email: ' + memberEmail + ' does not exist',
+        };
+      }
       return {
         member: (await (
-          await db.doc('members' + memberEmail).get()
+          await db.doc('members/' + memberEmail).get()
         ).data()) as Member,
         status: 200,
       };

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -1,7 +1,7 @@
-import { checkLoggedIn } from "./api";
-import { db } from "./firebase";
-import { PermissionsManager } from "./permissions";
-import { Request, Response } from "express";
+import { checkLoggedIn } from './api';
+import { db } from './firebase';
+import { PermissionsManager } from './permissions';
+import { Request, Response } from 'express';
 
 export type Member = {
   email: string;
@@ -25,7 +25,7 @@ export let allMembers = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     res.json({
       members: await db
-        .collection("members")
+        .collection('members')
         .get()
         .then((vals) => {
           return vals.docs.map((doc) => {
@@ -39,32 +39,32 @@ export let allMembers = async (req, res) => {
 export let setMember = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let member = await (
-      await db.doc("members/" + req.session.email).get()
+      await db.doc('members/' + req.session.email).get()
     ).data();
     if (!member) {
       res
         .status(200)
-        .json({ error: "No member with email: " + req.session.email });
+        .json({ error: 'No member with email: ' + req.session.email });
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit) {
         res.status(200).json({
           error:
-            "User with email: " +
+            'User with email: ' +
             req.session.email +
-            " does not have permission to edit members!",
+            ' does not have permission to edit members!',
         });
       } else {
-        if (!req.body.email || req.body.email === "") {
+        if (!req.body.email || req.body.email === '') {
           res
             .status(200)
             .json({ error: "Couldn't edit user with undefined email!" });
           return;
         }
-        db.doc("members/" + req.body.email)
+        db.doc('members/' + req.body.email)
           .set(req.body)
           .then(() => {
-            res.status(200).json({ status: "Success", member: req.body });
+            res.status(200).json({ status: 'Success', member: req.body });
           })
           .catch((reason) => {
             res
@@ -79,43 +79,44 @@ export let setMember = async (req, res) => {
 export let updateMember = async (req: Request, res: Response) => {
   if (checkLoggedIn(req, res)) {
     let member = await (
-      await db.doc("members/" + req.session.email).get()
+      await db.doc('members/' + req.session.email).get()
     ).data();
     if (!member) {
       res
         .status(200)
-        .json({ error: "No member with email: " + req.session.email });
+        .json({ error: 'No member with email: ' + req.session.email });
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit && member.email !== req.body.email) {
         // members are able to edit their own information
         res.status(200).json({
           error:
-            "User with email: " +
+            'User with email: ' +
             req.session.email +
-            " does not have permission to edit members!",
+            ' does not have permission to edit members!',
         });
       } else {
-        if (!req.body.email || req.body.email === "") {
+        if (!req.body.email || req.body.email === '') {
           res
             .status(200)
             .json({ error: "Couldn't edit user with undefined email!" });
           return;
         }
         if (
-          (req.body.role || req.body.first_name || req.body.last_name) && !canEdit
+          (req.body.role || req.body.first_name || req.body.last_name) &&
+          !canEdit
         ) {
           res.status(200).json({
             error:
-              "User with email: " +
+              'User with email: ' +
               req.session.email +
-              " does not have permission to edit member name or roles!",
+              ' does not have permission to edit member name or roles!',
           });
         }
-        db.doc("members/" + req.body.email)
+        db.doc('members/' + req.body.email)
           .update(req.body)
           .then(() => {
-            res.status(200).json({ status: "Success", member: req.body });
+            res.status(200).json({ status: 'Success', member: req.body });
           })
           .catch((reason) => {
             res
@@ -128,36 +129,52 @@ export let updateMember = async (req: Request, res: Response) => {
 };
 
 export let getMember = async (req: Request, res: Response) => {
-  if(checkLoggedIn(req, res)) {
+  console.log(req.session.email);
+  if (checkLoggedIn(req, res)) {
     let member = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
-    if(!member) {
-      res
+    console.log(member);
+    if (!member) {
+      res // TODO: change the response status code
         .status(200)
-        .json({ error: "No member with email: " + req.session.email });
+        .json({ error: 'No member with email:' + req.session.email });
+    } else {
+      let canEdit: boolean = PermissionsManager.canEditMembers(member.role);
+      let memberEmail: string = req.params.email;
+      if (!canEdit && memberEmail !== req.session.email) {
+        // TODO: change the response status code
+        res.status(200).json({
+          error:
+            'User with email: ' +
+            req.session.email +
+            ' does not have permission to edit members!',
+        });
+      }
+      res.status(200).json({
+        member: await (await db.doc('members/' + memberEmail).get()).data(),
+      });
     }
-    res.json({ member: member })
   }
-}
+};
 
 export let deleteMember = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let member = await (
-      await db.doc("members/" + req.session.email).get()
+      await db.doc('members/' + req.session.email).get()
     ).data();
     if (!member) {
       res
         .status(200)
-        .json({ error: "No member with email: " + req.session.email });
+        .json({ error: 'No member with email: ' + req.session.email });
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit) {
         res.status(200).json({
           error:
-            "User with email: " +
+            'User with email: ' +
             req.session.email +
-            " does not have permission to edit members!",
+            ' does not have permission to edit members!',
         });
       }
     }

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -161,9 +161,7 @@ export let getMember = async (
         };
       }
       return {
-        member: (await (
-          await db.doc('members/' + memberEmail).get()
-        ).data()) as Member,
+        member: member as Member,
         status: 200,
       };
     }

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -109,7 +109,7 @@ export let updateMember = async (req: Request, res: Response) => {
             error:
               "User with email: " +
               req.session.email +
-              " does not have persmission to edit member name or roles!",
+              " does not have permission to edit member name or roles!",
           });
         }
         db.doc("members/" + req.body.email)
@@ -127,6 +127,20 @@ export let updateMember = async (req: Request, res: Response) => {
   }
 };
 
+export let getMember = async (req: Request, res: Response) => {
+  if(checkLoggedIn(req, res)) {
+    let member = await (
+      await db.doc('members/' + req.session.email).get()
+    ).data();
+    if(!member) {
+      res
+        .status(200)
+        .json({ error: "No member with email: " + req.session.email });
+    }
+    res.json({ member: member })
+  }
+}
+
 export let deleteMember = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let member = await (
@@ -135,7 +149,7 @@ export let deleteMember = async (req, res) => {
     if (!member) {
       res
         .status(200)
-        .json({ error: "Not member with email: " + req.session.email });
+        .json({ error: "No member with email: " + req.session.email });
     } else {
       let canEdit = PermissionsManager.canEditMembers(member.role);
       if (!canEdit) {

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -48,7 +48,8 @@ export let setMember = async (
             status: 400,
           };
         }
-        db.doc('members/' + req.body.email)
+        let response: ErrorResponse | MemberResponse = await db
+          .doc('members/' + req.body.email)
           .set(req.body)
           .then(() => {
             return { status: 200, member: req.body };
@@ -59,6 +60,7 @@ export let setMember = async (
               status: 500,
             };
           });
+        return response;
       }
     }
   }

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -133,8 +133,9 @@ export let getMember = async (
   res: Response
 ): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
-    let user = await (await db.doc('members/' + req.session.email).get()
-      .data();
+    let user = await (
+      await db.doc('members/' + req.session.email).get()
+    ).data();
     if (!user) {
       return {
         error: 'No member with email: ' + req.session.email,

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -6,7 +6,20 @@ export type Member = {
   email: string,
   first_name: string,
   last_name: string,
-  role: string
+  name: string,
+  role: string,
+  graduation: string,
+  major: string,
+  doubleMajor?: string, //optional
+  minor?: string, //optional
+  website: string,
+  linkedin: string,
+  github: string,
+  hometown: string,
+  about: string,
+  subteam: string,
+  roleId: string,
+  roleDeveloper: string
 }
 
 export let allMembers = async (req, res) => {

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -7,15 +7,14 @@ export type Member = {
   email: string;
   first_name: string;
   last_name: string;
-  name: string;
   role: string;
   graduation: string;
   major: string;
   double_major?: string; //optional
   minor?: string; //optional
-  website: string;
-  linkedin_link: string;
-  github_link: string;
+  website?: string; //optional
+  linkedin_link?: string; //optional
+  github_link?: string; //optional
   hometown: string;
   about: string;
   subteam: string;
@@ -104,14 +103,13 @@ export let updateMember = async (req: Request, res: Response) => {
           return;
         }
         if (
-          req.body.role &&
-          !PermissionsManager.canEditMemberRole(member.role)
+          (req.body.role || req.body.first_name || req.body.last_name) && !canEdit
         ) {
           res.status(200).json({
             error:
               "User with email: " +
               req.session.email +
-              " does not have persmission to edit member roles!",
+              " does not have persmission to edit member name or roles!",
           });
         }
         db.doc("members/" + req.body.email)

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -124,86 +124,39 @@ export let updateMember = async (
   }
 };
 
-// export let updateMember = async (
-//   req: Request,
-//   res: Response
-// ): Promise<UpdateMemberResponse | ErrorResponse> => {
-//   if (checkLoggedIn(req, res)) {
-//     let member = await (
-//       await db.doc('members/' + req.session.email).get()
-//     ).data();
-//     if (!member) {
-//       res
-//         .status(401)
-//         .json({ error: 'No member with email: ' + req.session.email });
-//     } else {
-//       let canEdit = PermissionsManager.canEditMembers(member.role);
-//       if (!canEdit && member.email !== req.body.email) {
-//         // members are able to edit their own information
-//         res.status(403).json({
-//           error:
-//             'User with email: ' +
-//             req.session.email +
-//             ' does not have permission to edit members!',
-//         });
-//       } else {
-//         if (!req.body.email || req.body.email === '') {
-//           res
-//             .status(400)
-//             .json({ error: "Couldn't edit user with undefined email!" });
-//           return;
-//         }
-//         if (
-//           (req.body.role || req.body.first_name || req.body.last_name) &&
-//           !canEdit
-//         ) {
-//           res.status(403).json({
-//             error:
-//               'User with email: ' +
-//               req.session.email +
-//               ' does not have permission to edit member name or roles!',
-//           });
-//         }
-//         db.doc('members/' + req.body.email)
-//           .update(req.body)
-//           .then(() => {
-//             res.status(200).json({ status: 'Success', member: req.body });
-//           })
-//           .catch((reason) => {
-//             res
-//               .status(500)
-//               .json({ error: "Couldn't edit user for reason: " + reason });
-//           });
-//       }
-//     }
-//   }
-// };
-
-export let getMember = async (req: Request, res: Response) => {
+export let getMember = async (
+  req: Request,
+  res: Response
+): Promise<MemberResponse | ErrorResponse> => {
   console.log(req.session.email);
   if (checkLoggedIn(req, res)) {
     let member = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
-    console.log(member);
     if (!member) {
-      res
-        .status(401)
-        .json({ error: 'No member with email:' + req.session.email });
+      return {
+        error: 'No member with email: ' + req.session.email,
+        status: 401,
+      };
     } else {
       let canEdit: boolean = PermissionsManager.canEditMembers(member.role);
       let memberEmail: string = req.params.email;
       if (!canEdit && memberEmail !== req.session.email) {
-        res.status(403).json({
+        return {
           error:
             'User with email: ' +
             req.session.email +
             ' does not have permission to edit members!',
-        });
+          status: 403,
+        };
       }
-      res.status(200).json({
-        member: await (await db.doc('members/' + memberEmail).get()).data(),
-      });
+
+      return {
+        member: (await (
+          await db.doc('members' + memberEmail).get()
+        ).data()) as Member,
+        status: 200,
+      };
     }
   }
 };

--- a/src/memberAPI.ts
+++ b/src/memberAPI.ts
@@ -23,16 +23,16 @@ export let setMember = async (
   res
 ): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
-    let member = await (
+    let user = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
-    if (!member) {
+    if (!user) {
       return {
-        error: 'No member with email: ' + req.session.email,
+        error: 'No user with email: ' + req.session.email,
         status: 401,
       };
     } else {
-      let canEdit = PermissionsManager.canEditMembers(member.role);
+      let canEdit = PermissionsManager.canEditMembers(user.role);
       if (!canEdit) {
         return {
           error:
@@ -44,7 +44,7 @@ export let setMember = async (
       } else {
         if (!req.body.email || req.body.email === '') {
           return {
-            error: "Couldn't edit user with undefined email!",
+            error: "Couldn't edit member with undefined email!",
             status: 400,
           };
         }
@@ -56,7 +56,7 @@ export let setMember = async (
           })
           .catch((reason) => {
             return {
-              error: "Couldn't edit user for reason: " + reason,
+              error: "Couldn't edit member for reason: " + reason,
               status: 500,
             };
           });
@@ -71,17 +71,17 @@ export let updateMember = async (
   res: Response
 ): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
-    let member = await (
+    let user = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
-    if (!member) {
+    if (!user) {
       return {
-        error: 'No member with email: ' + req.session.email,
+        error: 'No user with email: ' + req.session.email,
         status: 401,
       };
     } else {
-      let canEdit: boolean = PermissionsManager.canEditMembers(member.role);
-      if (!canEdit && member.email !== req.body.email) {
+      let canEdit: boolean = PermissionsManager.canEditMembers(user.role);
+      if (!canEdit && user.email !== req.body.email) {
         return {
           error:
             'User with email: ' +
@@ -92,7 +92,7 @@ export let updateMember = async (
       } else {
         if (!req.body.email || req.body.email === '') {
           return {
-            error: "Couldn't edit user with undefined email!",
+            error: "Couldn't edit member with undefined email!",
             status: 400,
           };
         }
@@ -119,7 +119,7 @@ export let updateMember = async (
           })
           .catch((reason) => {
             return {
-              error: "Couldn't edit user for reason: " + reason,
+              error: "Couldn't edit member for reason: " + reason,
               status: 500,
             };
           });
@@ -140,7 +140,7 @@ export let getMember = async (
     ).data();
     if (!user) {
       return {
-        error: 'No member with email: ' + req.session.email,
+        error: 'No user with email: ' + req.session.email,
         status: 401,
       };
     } else {
@@ -175,16 +175,16 @@ export let deleteMember = async (
   res
 ): Promise<MemberResponse | ErrorResponse> => {
   if (checkLoggedIn(req, res)) {
-    let member = await (
+    let user = await (
       await db.doc('members/' + req.session.email).get()
     ).data();
-    if (!member) {
+    if (!user) {
       return {
-        error: 'No member with email: ' + req.session.email,
+        error: 'No user with email: ' + req.session.email,
         status: 401,
       };
     } else {
-      let canEdit = PermissionsManager.canEditMembers(member.role);
+      let canEdit = PermissionsManager.canEditMembers(user.role);
       if (!canEdit) {
         return {
           error:
@@ -196,7 +196,7 @@ export let deleteMember = async (
       } else {
         if (!req.body.email || req.body.email === '') {
           return {
-            error: "Couldn't delete user with undefined email!",
+            error: "Couldn't delete member with undefined email!",
             status: 400,
           };
         }
@@ -211,7 +211,7 @@ export let deleteMember = async (
           })
           .catch((reason) => {
             return {
-              error: "Couldn't delete user for reason: " + reason,
+              error: "Couldn't delete member for reason: " + reason,
               status: 500,
             };
           });

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,16 +1,17 @@
-export type role = "lead" | "admin" | "tpm" | "pm" | "developer" | "designer";
+import { role } from './DataTypes';
+
 export const allRoles: role[] = [
-  "lead",
-  "admin",
-  "tpm",
-  "pm",
-  "developer",
-  "designer",
+  'lead',
+  'admin',
+  'tpm',
+  'pm',
+  'developer',
+  'designer',
 ];
 
 export class PermissionsManager {
   static canEditMembers(role: role): boolean {
-    if (role === "lead" || role === "admin") {
+    if (role === 'lead' || role === 'admin') {
       return true;
     } else {
       return false;
@@ -18,7 +19,7 @@ export class PermissionsManager {
   }
 
   static canEditTeams(role: role): boolean {
-    if (role === "lead" || role === "admin") {
+    if (role === 'lead' || role === 'admin') {
       return true;
     } else {
       return false;

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,10 +1,16 @@
-export type role = 'lead' | 'admin' | 'tpm' | 'pm' | 'developer' | 'designer';
-export const allRoles: role[] = ['lead', 'admin', 'tpm', 'pm', 'developer', 'designer'];
+export type role = "lead" | "admin" | "tpm" | "pm" | "developer" | "designer";
+export const allRoles: role[] = [
+  "lead",
+  "admin",
+  "tpm",
+  "pm",
+  "developer",
+  "designer",
+];
 
 export class PermissionsManager {
-
   static canEditMembers(role: role): boolean {
-    if (role === 'lead' || role === 'admin') {
+    if (role === "lead" || role === "admin") {
       return true;
     } else {
       return false;
@@ -12,11 +18,18 @@ export class PermissionsManager {
   }
 
   static canEditTeams(role: role): boolean {
-    if (role === 'lead' || role === 'admin') {
+    if (role === "lead" || role === "admin") {
       return true;
     } else {
       return false;
     }
   }
 
+  static canEditMemberRole(role: role): boolean {
+    if (role === "lead" || role === "admin") {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -24,12 +24,4 @@ export class PermissionsManager {
       return false;
     }
   }
-
-  static canEditMemberRole(role: role): boolean {
-    if (role === "lead" || role === "admin") {
-      return true;
-    } else {
-      return false;
-    }
-  }
 }

--- a/src/teamAPI.ts
+++ b/src/teamAPI.ts
@@ -5,37 +5,46 @@ import { checkLoggedIn } from "./api";
 import { firestore } from "firebase-admin";
 import { materialize } from "./util";
 import { Member } from "./memberAPI";
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 
 export type DBTeam = {
-  uuid: string,
-  name: string,
-  leaders: firestore.DocumentReference[],
-  members: firestore.DocumentReference[]
-}
+  uuid: string;
+  name: string;
+  leaders: firestore.DocumentReference[];
+  members: firestore.DocumentReference[];
+};
 
 export type Team = {
-  uuid: string,
-  name: string,
-  leaders: Member[],
-  members: Member[]
-}
+  uuid: string;
+  name: string;
+  leaders: Member[];
+  members: Member[];
+};
 
 export let allTeams = async (req, res) => {
   if (checkLoggedIn(req, res)) {
-    let teamRefs = await db.collection('teams').get();
-    let resp = await Promise.all(teamRefs.docs.map(teamRef => materialize(teamRef.data())));
+    let teamRefs = await db.collection("teams").get();
+    let resp = await Promise.all(
+      teamRefs.docs.map((teamRef) => materialize(teamRef.data()))
+    );
     res.json({ teams: resp });
   }
-}
+};
 
 export let setTeam = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let teamBody = req.body as Team;
-    let member = await (await db.doc('members/' + req.session.email).get()).data();
+    let member = await (
+      await db.doc("members/" + req.session.email).get()
+    ).data();
     let canEdit = PermissionsManager.canEditTeams(member.role);
     if (!canEdit) {
-      res.status(200).json({ error: "User with email: " + req.session.email + " does not have permission to edit teams!" });
+      res.status(200).json({
+        error:
+          "User with email: " +
+          req.session.email +
+          " does not have permission to edit teams!",
+      });
     } else {
       if (teamBody.leaders.length > 0 && !teamBody.leaders[0].email) {
         res.status(200).json({ error: "Malformed leaders on POST!" });
@@ -48,18 +57,34 @@ export let setTeam = async (req, res) => {
       let teamRef: DBTeam = {
         uuid: teamBody.uuid ? teamBody.uuid : uuidv4(),
         name: teamBody.name,
-        leaders: teamBody.leaders.map(leader => db.doc('members/' + leader.email)),
-        members: teamBody.members.map(mem => db.doc('members/' + mem.email))
+        leaders: teamBody.leaders.map((leader) =>
+          db.doc("members/" + leader.email)
+        ),
+        members: teamBody.members.map((mem) => db.doc("members/" + mem.email)),
       };
-      let existRes = await Promise.all(teamRef.leaders.concat(teamRef.members).map(ref => ref.get().then(val => val.exists)));
-      if (existRes.findIndex(val => val === false) != -1) {
-        res.status(200).json({ error: "Couldn't create team from members that don't exist!" });
-      } else {
-        db.doc('teams/' + teamRef.uuid).set(teamRef).then(() => {
-          res.status(200).json({ status: "Success", team: { ...teamBody, uuid: teamRef.uuid } });
-        }).catch((reason) => {
-          res.status(200).json({ error: "Couldn't edit team for reason: " + reason });
+      let existRes = await Promise.all(
+        teamRef.leaders
+          .concat(teamRef.members)
+          .map((ref) => ref.get().then((val) => val.exists))
+      );
+      if (existRes.findIndex((val) => val === false) != -1) {
+        res.status(200).json({
+          error: "Couldn't create team from members that don't exist!",
         });
+      } else {
+        db.doc("teams/" + teamRef.uuid)
+          .set(teamRef)
+          .then(() => {
+            res.status(200).json({
+              status: "Success",
+              team: { ...teamBody, uuid: teamRef.uuid },
+            });
+          })
+          .catch((reason) => {
+            res
+              .status(200)
+              .json({ error: "Couldn't edit team for reason: " + reason });
+          });
       }
     }
   }
@@ -68,24 +93,38 @@ export let setTeam = async (req, res) => {
 export let deleteTeam = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let teamBody = req.body as Team;
-    if (!teamBody.uuid || teamBody.uuid === '') {
-      res.status(200).json({ error: "Couldn't delete team with undefined uuid!" });
+    if (!teamBody.uuid || teamBody.uuid === "") {
+      res
+        .status(200)
+        .json({ error: "Couldn't delete team with undefined uuid!" });
       return;
     }
-    let member = await (await db.doc('members/' + req.session.email).get()).data();
-    let teamSnap = await (await db.doc('teams/' + teamBody.uuid).get());
+    let member = await (
+      await db.doc("members/" + req.session.email).get()
+    ).data();
+    let teamSnap = await await db.doc("teams/" + teamBody.uuid).get();
     if (!teamSnap.exists) {
       res.status(200).json({ error: "No team with uuid: " + teamBody.uuid });
     } else {
       let canEdit = PermissionsManager.canEditTeams(member.role);
       if (!canEdit) {
-        res.status(200).json({ error: "User with email: " + req.session.email + " does not have permission to delete teams!" });
-      } else {
-        db.doc('teams/' + teamBody.uuid).delete().then(() => {
-          res.status(200).json({ status: "Success", team: teamBody });
-        }).catch((reason) => {
-          res.status(200).json({ error: "Couldn't delete team for reason: " + reason });
+        res.status(200).json({
+          error:
+            "User with email: " +
+            req.session.email +
+            " does not have permission to delete teams!",
         });
+      } else {
+        db.doc("teams/" + teamBody.uuid)
+          .delete()
+          .then(() => {
+            res.status(200).json({ status: "Success", team: teamBody });
+          })
+          .catch((reason) => {
+            res
+              .status(200)
+              .json({ error: "Couldn't delete team for reason: " + reason });
+          });
       }
     }
   }

--- a/src/teamAPI.ts
+++ b/src/teamAPI.ts
@@ -1,29 +1,15 @@
-import { RequestHandler } from "express";
-import { db } from "./firebase";
-import { PermissionsManager } from "./permissions";
-import { checkLoggedIn } from "./api";
-import { firestore } from "firebase-admin";
-import { materialize } from "./util";
-import { Member } from "./memberAPI";
-import { v4 as uuidv4 } from "uuid";
-
-export type DBTeam = {
-  uuid: string;
-  name: string;
-  leaders: firestore.DocumentReference[];
-  members: firestore.DocumentReference[];
-};
-
-export type Team = {
-  uuid: string;
-  name: string;
-  leaders: Member[];
-  members: Member[];
-};
+import { RequestHandler } from 'express';
+import { db } from './firebase';
+import { PermissionsManager } from './permissions';
+import { checkLoggedIn } from './api';
+import { firestore } from 'firebase-admin';
+import { materialize } from './util';
+import { Member, DBTeam, Team } from './DataTypes';
+import { v4 as uuidv4 } from 'uuid';
 
 export let allTeams = async (req, res) => {
   if (checkLoggedIn(req, res)) {
-    let teamRefs = await db.collection("teams").get();
+    let teamRefs = await db.collection('teams').get();
     let resp = await Promise.all(
       teamRefs.docs.map((teamRef) => materialize(teamRef.data()))
     );
@@ -35,32 +21,32 @@ export let setTeam = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let teamBody = req.body as Team;
     let member = await (
-      await db.doc("members/" + req.session.email).get()
+      await db.doc('members/' + req.session.email).get()
     ).data();
     let canEdit = PermissionsManager.canEditTeams(member.role);
     if (!canEdit) {
       res.status(200).json({
         error:
-          "User with email: " +
+          'User with email: ' +
           req.session.email +
-          " does not have permission to edit teams!",
+          ' does not have permission to edit teams!',
       });
     } else {
       if (teamBody.leaders.length > 0 && !teamBody.leaders[0].email) {
-        res.status(200).json({ error: "Malformed leaders on POST!" });
+        res.status(200).json({ error: 'Malformed leaders on POST!' });
         return;
       }
       if (teamBody.members.length > 0 && !teamBody.members[0].email) {
-        res.status(200).json({ error: "Malformed members on POST!" });
+        res.status(200).json({ error: 'Malformed members on POST!' });
         return;
       }
       let teamRef: DBTeam = {
         uuid: teamBody.uuid ? teamBody.uuid : uuidv4(),
         name: teamBody.name,
         leaders: teamBody.leaders.map((leader) =>
-          db.doc("members/" + leader.email)
+          db.doc('members/' + leader.email)
         ),
-        members: teamBody.members.map((mem) => db.doc("members/" + mem.email)),
+        members: teamBody.members.map((mem) => db.doc('members/' + mem.email)),
       };
       let existRes = await Promise.all(
         teamRef.leaders
@@ -72,11 +58,11 @@ export let setTeam = async (req, res) => {
           error: "Couldn't create team from members that don't exist!",
         });
       } else {
-        db.doc("teams/" + teamRef.uuid)
+        db.doc('teams/' + teamRef.uuid)
           .set(teamRef)
           .then(() => {
             res.status(200).json({
-              status: "Success",
+              status: 'Success',
               team: { ...teamBody, uuid: teamRef.uuid },
             });
           })
@@ -93,32 +79,32 @@ export let setTeam = async (req, res) => {
 export let deleteTeam = async (req, res) => {
   if (checkLoggedIn(req, res)) {
     let teamBody = req.body as Team;
-    if (!teamBody.uuid || teamBody.uuid === "") {
+    if (!teamBody.uuid || teamBody.uuid === '') {
       res
         .status(200)
         .json({ error: "Couldn't delete team with undefined uuid!" });
       return;
     }
     let member = await (
-      await db.doc("members/" + req.session.email).get()
+      await db.doc('members/' + req.session.email).get()
     ).data();
-    let teamSnap = await await db.doc("teams/" + teamBody.uuid).get();
+    let teamSnap = await await db.doc('teams/' + teamBody.uuid).get();
     if (!teamSnap.exists) {
-      res.status(200).json({ error: "No team with uuid: " + teamBody.uuid });
+      res.status(200).json({ error: 'No team with uuid: ' + teamBody.uuid });
     } else {
       let canEdit = PermissionsManager.canEditTeams(member.role);
       if (!canEdit) {
         res.status(200).json({
           error:
-            "User with email: " +
+            'User with email: ' +
             req.session.email +
-            " does not have permission to delete teams!",
+            ' does not have permission to delete teams!',
         });
       } else {
-        db.doc("teams/" + teamBody.uuid)
+        db.doc('teams/' + teamBody.uuid)
           .delete()
           .then(() => {
-            res.status(200).json({ status: "Success", team: teamBody });
+            res.status(200).json({ status: 'Success', team: teamBody });
           })
           .catch((reason) => {
             res

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,12 +9,14 @@ import { isUndefined } from "util";
  *
  * @param coll the collection to convert into a docref array
  */
-export async function docRefArrayFromCollectionRef(coll: firestore.CollectionReference): Promise<Array<any>> {
+export async function docRefArrayFromCollectionRef(
+  coll: firestore.CollectionReference
+): Promise<Array<any>> {
   // Init array
   let insArr: firestore.DocumentReference[] = [];
   // Go through each doc and add their reference
-  return coll.get().then(snapshot => {
-    snapshot.forEach(element => {
+  return coll.get().then((snapshot) => {
+    snapshot.forEach((element) => {
       insArr.push(element.ref);
     });
     return insArr;
@@ -33,7 +35,10 @@ const maxDepthDefault = 5;
  * @param object The object to materialize
  * @param depth The maximum depth of materialization (maxDepthDefault = 5)
  */
-export async function materialize(object?: firestore.DocumentData, depth = maxDepthDefault): Promise<any> {
+export async function materialize(
+  object?: firestore.DocumentData,
+  depth = maxDepthDefault
+): Promise<any> {
   return new Promise((res, rej) => {
     if (depth <= 0) {
       res(object);
@@ -49,31 +54,40 @@ export async function materialize(object?: firestore.DocumentData, depth = maxDe
       if (Object.prototype.hasOwnProperty.call(objectStruct, prop)) {
         if (isDocRef(objectStruct[prop])) {
           let ref = objectStruct[prop] as firestore.DocumentReference;
-          let dataProm = ref.get().then(val => val.data()).then((data) => {
-            return materialize(data, depth - 1);
-          });
+          let dataProm = ref
+            .get()
+            .then((val) => val.data())
+            .then((data) => {
+              return materialize(data, depth - 1);
+            });
           propToProm.push([prop, dataProm]);
           foundAProp = true;
-        }
-        else if (objectStruct[prop] instanceof Array && objectStruct[prop].length > 0
-          && isDocRef(objectStruct[prop][0])) {
+        } else if (
+          objectStruct[prop] instanceof Array &&
+          objectStruct[prop].length > 0 &&
+          isDocRef(objectStruct[prop][0])
+        ) {
           let refArr = objectStruct[prop] as Array<firestore.DocumentReference>;
           let groupProm = [];
           for (let i = 0; i < refArr.length; i++) {
             let ref = refArr[i];
-            let dataProm = ref.get().then(valRet => valRet.data()).then(data => {
-              return materialize(data, depth - 1);
-            });
+            let dataProm = ref
+              .get()
+              .then((valRet) => valRet.data())
+              .then((data) => {
+                return materialize(data, depth - 1);
+              });
             groupProm.push(dataProm);
           }
           propToProm.push([prop, Promise.all(groupProm)]);
           foundAProp = true;
-        }
-        else if (isCollRef(objectStruct[prop])) {
+        } else if (isCollRef(objectStruct[prop])) {
           let collection = objectStruct[prop] as firestore.CollectionReference;
-          let promRet = docRefArrayFromCollectionRef(collection).then(colAsArr => {
-            return materialize(colAsArr, depth - 1);
-          });
+          let promRet = docRefArrayFromCollectionRef(collection).then(
+            (colAsArr) => {
+              return materialize(colAsArr, depth - 1);
+            }
+          );
           propToProm.push([prop, promRet]);
           foundAProp = true;
         }
@@ -96,13 +110,17 @@ export async function materialize(object?: firestore.DocumentData, depth = maxDe
 }
 
 function isDocRef(val: any) {
-  return typeof (val.collection) === 'function'
-    && typeof (val.doc) === 'undefined'
-    && typeof (val.startAfter) === 'undefined'
+  return (
+    typeof val.collection === "function" &&
+    typeof val.doc === "undefined" &&
+    typeof val.startAfter === "undefined"
+  );
 }
 
 function isCollRef(val: any) {
-  return typeof (val.collection) === 'undefined'
-    && typeof (val.doc) === 'function'
-    && typeof (val.startAfter) === 'function'
+  return (
+    typeof val.collection === "undefined" &&
+    typeof val.doc === "function" &&
+    typeof val.startAfter === "function"
+  );
 }


### PR DESCRIPTION
### Summary 

This PR is the first step in refactoring the IDOL backend API that adds data types for members and teams in addition to creating response types for the member endpoints. 

In addition, specific HTTP status codes have also been added to the member endpoints:
- 200: Successful request
- 400: Empty email in request body
- 401: Current user does not exist in database
- 403: Current user does not have permission
- 404: Requested user doesn't exist 
- 500: Any error with database 

### Test Plan

Same test plan as PR #9:
- Check if the user can update their general info correctly
- Check if user can only update their information and not another user's (unless their role is admin or lead)
- Check if only admins/leads can update the role
- Check if only admins/leads can update the first name/last name  

### Notes
- Not sure if there is a way that the data and api types in the .d.ts files can be auto-imported into each file
- The data types for members, teams, and roles have only been moved and remain the same 
- The status field for response bodies have been changed to a number (from string) that is the HTTP status code
